### PR TITLE
Remove unpause as an alias for resume

### DIFF
--- a/commands/music/resume.js
+++ b/commands/music/resume.js
@@ -4,7 +4,7 @@ module.exports = class extends Command {
   constructor (client) {
     super(client, {
       name: "resume",
-      aliases: ["unpause"],
+      aliases: [],
       group: "music",
       memberName: "resume",
       description: "Resumes the current paused song",


### PR DESCRIPTION
Mainly to spite Keef, also because its not very intuitive