### PR TITLE
Fixed error with bot trying to edit deleted embeds

### DIFF
--- a/src/classes/MusicTracker.js
+++ b/src/classes/MusicTracker.js
@@ -6,7 +6,6 @@ export default class {
   async run (msg) {
     try {
       const te = new TrackExtractor(msg.content)
-      console.log("Parsed links:", te.links)
       
       if (te.parseLinks()) {
         const filteredLinks = te.links.slice(0, 25).filter(l => [PLATFORM_SPOTIFY, PLATFORM_TIDAL, PLATFORM_APPLE].includes(l.platform) && ["track", "album", "artist"].includes(l.type))


### PR DESCRIPTION
This pull request improves error handling and message management in the `TopMostMessagePump` class, ensuring the bot responds more gracefully when Discord messages are edited or deleted. It also removes a debug log from the `MusicTracker` class.

**Error handling and message lifecycle improvements:**

* When editing a message, the code now checks if the message still exists by fetching it first. If the message has been deleted (404 error), it creates a new message instead of failing.
* When editing a message fails due to deletion (404 error), the bot now creates a new message automatically.
* When deleting a message, if the message was already deleted (404 error), the reference is cleared to prevent stale pointers.

**Code cleanup:**

* Removed a debug log statement from `MusicTracker.js` to reduce console noise.