### PR TITLE
Bugfix/voteskip lmgtfy

### DIFF
--- a/src/classes/VoiceStateAdapter.js
+++ b/src/classes/VoiceStateAdapter.js
@@ -33,8 +33,8 @@ class VoiceStateAdapter extends EventEmitter {
         fromChannel: oldMember.channel,
         toChannel: newMember.channel,
         fromAfk: oldMember.channelId === oldMember.guild.afkChannelId,
-        toAfk: newMember.channelId === oldMember.guild.afkChannelId,
-        voiceState: oldMember,
+        toAfk: newMember.channelId === newMember.guild.afkChannelId,
+        voiceState: newMember,
       })
     }
     // Wasn't a voice channel change

--- a/src/commands/misc/lmgtfy.js
+++ b/src/commands/misc/lmgtfy.js
@@ -8,18 +8,27 @@ export default class extends Command {
       group: "misc",
       memberName: "lmgtfy",
       description: "A response to a snooty response to someone asking for help",
-      args: [],
+      args: [
+        {
+          key: "query",
+          prompt: "What should I google for them?",
+          type: "string",
+        },
+      ],
       guildOnly: true,
     })
   }
 
   async run (msg, args) {
-    if (encodeURI("https://letmegooglethat.com/?q=" + args).length > 1999) {
-      args = "That was too big"
-      msg.reply(`The person was just asking for help, ${msg.author.username} you wet egg. ${encodeURI("https://letmegooglethat.com/?q=" + args)}`)
+    const query = args.query
+    const encodedQuery = encodeURIComponent(query)
+    const url = `https://letmegooglethat.com/?q=${encodedQuery}`
+    
+    if (url.length > 1999) {
+      msg.reply(`The person was just asking for help, ${msg.author.username} you wet egg and your link was too long`)
     }
     else {
-      msg.reply(`The person was just asking for help, ${msg.author.username} you wet egg. ${encodeURI("https://letmegooglethat.com/?q=" + args)}`)
+      msg.reply(`The person was just asking for help, ${msg.author.username} you wet egg. ${url}`)
     }
   }
 }


### PR DESCRIPTION
This pull request introduces improvements and bug fixes to the music and misc command modules, as well as a minor correction in the voice state adapter. The main focus is on enhancing the reliability and user experience of the `voteskip` music command and refining the argument handling for the `lmgtfy` command.

**Music Command Improvements:**

* Improved the `voteskip` command by ensuring the bot is connected to a voice channel before proceeding, preventing errors when the command is used while the bot is disconnected.
* Refactored the voting logic in the `voteskip` command to use a reaction collector that resolves as soon as a majority is reached or after a timeout, making the vote handling more robust and responsive.

**Misc Command Enhancements:**

* Updated the `lmgtfy` command to explicitly require a `query` argument, properly encode the provided query, and improve handling of excessively long queries, resulting in more reliable and user-friendly responses.

**Bug Fixes:**

* Fixed a bug in the `VoiceStateAdapter` where the `toAfk` property and `voiceState` reference could be incorrect by ensuring they reference the correct `guild` and member objects.